### PR TITLE
fix: forward data to websocket without transform

### DIFF
--- a/socketdock/api.py
+++ b/socketdock/api.py
@@ -49,7 +49,7 @@ async def socket_send(request: Request, connectionid: str):
         return text("FAIL", status=500)
 
     socket = active_connections[connectionid]
-    await socket.send(request.body.decode("utf-8"))
+    await socket.send(request.body)
     return text("OK")
 
 


### PR DESCRIPTION
Don't decode the request.body when forwarding data from the API endpoint to the websocket. Pass the information verbatim in whatever format (binary or text) it may be.