### PR TITLE
Disable status call until auth mechanisms

### DIFF
--- a/socketdock/api.py
+++ b/socketdock/api.py
@@ -21,7 +21,9 @@ active_connections = {}
 lifetime_connections = 0
 
 
-@api.get("/status")
+# Temporarily disabled due to lack of authorization
+# TODO: Add route authorization controls
+# @api.get("/status")
 async def status_handler(request: Request):
     """Return status information about the server."""
     uptime = time.time_ns() - LAUNCH_TIME


### PR DESCRIPTION
The status call has no authentication associated with it. This is great for development, but not-so-great for production. Until a better way to limit the audience, we should probably disable this for now.